### PR TITLE
Update wp-d3.php

### DIFF
--- a/trunk/wp-d3.php
+++ b/trunk/wp-d3.php
@@ -66,6 +66,6 @@ add_shortcode("d3-source", "print_source");
 remove_filter('the_content', 'wptexturize');
 remove_filter('the_content', 'wpautop' );
 // and added again with less priority
-// add_filter( 'the_content', 'wpautop' , 99);
-//add_filter( 'the_content', 'wptexturize' , 99);
+add_filter( 'the_content', 'wpautop' , 99);
+add_filter( 'the_content', 'wptexturize' , 99);
 ?>


### PR DESCRIPTION
Creo que se te ha olvidado descomentar wpautop o es algo consciente?

Te han puesto un ticket en la página de wordpress por ello: http://wordpress.org/support/topic/wp-d3-plugin-destroys-newline-characters-in-wp-36
